### PR TITLE
Salto Deployment: second comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## [second comparison](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/6c1f64a5-b4b5-48e2-9d40-b65707cedb7f/deployments/9524c3c8-7807-4b67-843a-7a27f4d4ef4c)
+
+Source Environment: [ns-dev](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/ca481ced-2058-49f5-adbd-a3fbb7b3884c) 
+
+Target Environment: [ns-prod](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/6c1f64a5-b4b5-48e2-9d40-b65707cedb7f) 
+
+Author: Geoffrey Routledge

--- a/envs/ns-prod/static-resources/netsuite/FileCabinet/SuiteScripts/gwr/gwr_sa3.js
+++ b/envs/ns-prod/static-resources/netsuite/FileCabinet/SuiteScripts/gwr/gwr_sa3.js
@@ -7,6 +7,9 @@ define(['N/log'],
  * @param{log} log
  */
 
+    // 20230925-235310
+    // 20230926-000024
+
     /**
       * change 1
       */
@@ -21,14 +24,7 @@ define(['N/log'],
         const onRequest = (scriptContext) => {
             const a = 2
             workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
-            workflow.get({ name: 'custbody_aw_second_lvl_approval' })
+            // 20230912-223153
        }
       /**
         * change 2


### PR DESCRIPTION

Salto [deployment](https://app.salto.io/orgs/3ab0fb5b-95a7-497b-836a-2583702766e1/envs/6c1f64a5-b4b5-48e2-9d40-b65707cedb7f/deployments/9524c3c8-7807-4b67-843a-7a27f4d4ef4c) from ns-dev to ns-prod.




